### PR TITLE
fix: implement OrderLine component in draft order details and removing tax prefiguring for item. [NHD-523]

### DIFF
--- a/src/domain/orders/details/order-line/index.tsx
+++ b/src/domain/orders/details/order-line/index.tsx
@@ -26,7 +26,6 @@ const OrderLine = ({ item, region }) => {
               amount: item.unit_price,
               currency: region?.currency_code,
               digits: 2,
-              tax: region?.tax_rate,
             })}
           </div>
           <div className="inter-small-regular text-grey-50">
@@ -37,7 +36,6 @@ const OrderLine = ({ item, region }) => {
               amount: item.unit_price * item.quantity,
               currency: region?.currency_code,
               digits: 2,
-              tax: region?.tax_rate,
             })}
           </div>
         </div>

--- a/src/domain/orders/draft-orders/details.tsx
+++ b/src/domain/orders/draft-orders/details.tsx
@@ -31,6 +31,7 @@ import CopyToClipboard from "../../../components/atoms/copy-to-clipboard"
 import medusaApi from "../../../services/api"
 import { queryClient } from "../../../services/config"
 import { DiscountModal } from "../../../components/discount-modal/DiscountModal"
+import OrderLine from "../details/order-line"
 
 export interface DiscountOption {
   label: string
@@ -284,64 +285,8 @@ const DraftOrderDetails = ({ id }) => {
               }
             >
               <div className="mt-6">
-                {cart?.items?.map((item, i) => (
-                  <div
-                    key={i}
-                    className="flex justify-between mb-1 h-[64px] py-2 mx-[-5px] px-[5px] hover:bg-grey-5 rounded-rounded"
-                  >
-                    <div className="flex space-x-4 justify-center">
-                      <div className="flex h-[48px] w-[36px] rounded-rounded bg-grey-10 items-center justify-center">
-                        {item?.thumbnail ? (
-                          <img
-                            src={item.thumbnail}
-                            className="rounded-rounded object-cover"
-                          />
-                        ) : (
-                          <div className="text-grey-30">
-                            <ImagePlaceholderIcon />
-                          </div>
-                        )}
-                      </div>
-                      <div className="flex flex-col justify-center">
-                        <span className="inter-small-regular text-grey-90 max-w-[225px] truncate">
-                          {item.title}
-                        </span>
-                        {item?.variant && (
-                          <span className="inter-small-regular text-grey-50">
-                            {item.variant.sku}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                    <div className="flex  items-center">
-                      <div className="flex small:space-x-2 medium:space-x-4 large:space-x-6 mr-3">
-                        <div className="inter-small-regular text-grey-50">
-                          {!!region?.currency_code &&
-                            formatAmountWithSymbol({
-                              amount: item.unit_price,
-                              currency: region.currency_code,
-                              digits: 2,
-                              tax: region?.tax_rate,
-                            })}
-                        </div>
-                        <div className="inter-small-regular text-grey-50">
-                          x {item.quantity}
-                        </div>
-                        <div className="inter-small-regular text-grey-90">
-                          {!!region?.currency_code &&
-                            formatAmountWithSymbol({
-                              amount: item.unit_price * item.quantity,
-                              currency: region?.currency_code,
-                              digits: 2,
-                              tax: region?.tax_rate,
-                            })}
-                        </div>
-                      </div>
-                      <div className="inter-small-regular text-grey-50">
-                        {region?.currency_code.toUpperCase()}
-                      </div>
-                    </div>
-                  </div>
+                {cart?.items.map((item, index) => (
+                  <OrderLine key={index} item={item} region={region} />
                 ))}
 
                 <DisplayTotal


### PR DESCRIPTION
https://lambdacurry.atlassian.net/browse/NHD-523

The `OrderLine` component was set to prefigure the tax on the line item when rendering its total, so I went ahead and removed that to reflect the subtotal amount of the line item. I also used the component in the draft order details to reduce the amount of code.